### PR TITLE
createStoreWith accepts either a function or an object with reducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Add the following script tag to your html:
 
 #### Initialization
 
+You can initialize ngRedux two ways:
+
+Function as the reducer argument for the `createStoreWith`:
+
 ```JS
 import reducers from './reducers';
 import { combineReducers } from 'redux';
@@ -53,6 +57,27 @@ angular.module('app', [ngRedux])
     $ngReduxProvider.createStoreWith(reducer, ['promiseMiddleware', loggingMiddleware]);
   });
 ```
+
+A reducer object as reducer argument for the `createStoreWith`:
+
+```JS
+import reducers from './reducers';
+import { combineReducers } from 'redux';
+import loggingMiddleware from './loggingMiddleware';
+import ngRedux from 'ng-redux';
+
+angular.module('app', [ngRedux])
+.config(($ngReduxProvider) => {
+	reducer3 = functtion(state, action){}
+    $ngReduxProvider.createStoreWith({
+		reducer1: "reducer1",
+		reducer2: function(state, action){},
+		reducer3: reducer3
+	 }, ['promiseMiddleware', loggingMiddleware]);
+  });
+```
+
+The object can be constructed either by passing a function as value or a string representing the reducer. This way, you can create reducers as services and initialze them inside the `.config`. Behind the secnes, ngRedux will `$injector.get` the string you pass as the value for the ojects of reducers and initilaze it.
 
 #### Usage
 

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -6,18 +6,18 @@ import digestMiddleware from './digestMiddleware';
 import assign from 'lodash.assign';
 import isArray from 'lodash.isarray';
 import isFunction from 'lodash.isfunction';
-import isObejct from 'lodash.isobject';
+import isObject from 'lodash.isobject';
 
 export default function ngReduxProvider() {
   let _reducer = undefined;
   let _middlewares = undefined;
   let _storeEnhancers = undefined;
   let _initialState = undefined;
-  let _reducerIsObejct = undefined;
+  let _reducerIsObject = undefined;
 
   this.createStoreWith = (reducer, middlewares, storeEnhancers, initialState) => {
     invariant(
-      isFunction(reducer) || isObejct(reducer),
+      isFunction(reducer) || isObject(reducer),
       'The reducer parameter passed to createStoreWith must be a Function or an Object. Instead received %s.',
       typeof reducer
     );
@@ -29,7 +29,7 @@ export default function ngReduxProvider() {
     );
 
     _reducer = reducer;
-    _reducerIsObejct = isObejct(reducer);
+    _reducerIsObject = isObject(reducer);
     _storeEnhancers = storeEnhancers
     _middlewares = middlewares || [];
     _initialState = initialState;
@@ -46,7 +46,7 @@ export default function ngReduxProvider() {
       }
     }
 
-    if(_reducerIsObejct) {
+    if(_reducerIsObject) {
       let reducersObj = {};
       let reducKeys = Object.keys(_reducer); 
 


### PR DESCRIPTION
Hi, 

This PR aims to solve this issue -> https://github.com/wbuchwalter/ng-redux/issues/75 but in a different manner. We've implemented a way to pass the reducer as a single Function or as an Object. This is extremely helpful because we can create the reducers as an angular services and initialize it in the .config.

The reducer object would accept a function or a string for its values. Using it as a string, we can later use $injector.get("myReducerAsService") and get it injected.

It'll work like this:

```angular.module("myapp").config([
  "$ngReduxProvider", "Redux"
  "ReduxThunk"
  (
    $ngReduxProvider, Redux, thunk
  ) ->
    $ngReduxProvider.createStoreWith({reducerAsService: "reducerAsService", reducerAsFunctions: fnction(){}}, [thunk])
    return
])```

Let me know what you think.
Thanks