### PR TITLE
Async reducers

### DIFF
--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -2,6 +2,7 @@ import Connector from './connector';
 import invariant from 'invariant';
 import {createStore, applyMiddleware, compose, combineReducers} from 'redux';
 import digestMiddleware from './digestMiddleware';
+import {addReducer, removeReducer} from '../utils/dynamicReducers';
 
 import assign from 'lodash.assign';
 import curry from 'lodash.curry';
@@ -19,6 +20,7 @@ export default function ngReduxProvider() {
   let _storeEnhancers = undefined;
   let _initialState = undefined;
   let _reducerIsObject = undefined;
+  let _fixedReducers = undefined;
 
   this.createStoreWith = (reducer, middlewares, storeEnhancers, initialState) => {
     invariant(
@@ -62,7 +64,7 @@ export default function ngReduxProvider() {
         { [key]: getReducerKey(key) }
       );
 
-      const reducersObj = Object
+      const reducersObj = _fixedReducers = Object
         .keys(_reducer)
         .reduce(resolveReducerKey, {});
 
@@ -75,10 +77,14 @@ export default function ngReduxProvider() {
     resolvedMiddleware.push(digestMiddleware($injector.get('$rootScope')));
 
     const store = _initialState
-      ? applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer, _initialState)
-      : applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer);
+      ? assign({ asyncReducers: {}, fixedReducers: _fixedReducers }, applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer, _initialState))
+      : assign({ asyncReducers: {}, fixedReducers: _fixedReducers }, applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer));
 
-    return assign({}, store, { connect: Connector(store) });
+    return assign({}, store, {
+      addReducer: addReducer(store),
+      connect: Connector(store),
+      removeReducer: removeReducer(store)
+    });
   };
 
   this.$get.$inject = ['$injector'];

--- a/src/utils/dynamicReducers.js
+++ b/src/utils/dynamicReducers.js
@@ -1,0 +1,20 @@
+import assign from 'lodash.assign';
+import { combineReducers } from 'redux';
+
+function _createReducer(fixedReducers, asyncReducers = {}) {
+  return combineReducers(assign({}, fixedReducers, asyncReducers));
+}
+
+export function addReducer(store) {
+  return (name, reducer) => {
+    store.asyncReducers[name] = reducer;
+    store.replaceReducer(_createReducer(store.fixedReducers, store.asyncReducers));
+  };
+}
+
+export function removeReducer(store) {
+  return (name) => {
+    delete store.asyncReducers[name];
+    store.replaceReducer(_createReducer(store.fixedReducers, store.asyncReducers));
+  };
+}

--- a/src/utils/dynamicReducers.js
+++ b/src/utils/dynamicReducers.js
@@ -1,5 +1,10 @@
 import assign from 'lodash.assign';
+import curry from 'lodash.curry';
+import invariant from 'invariant';
 import { combineReducers } from 'redux';
+
+const typeIs = curry((type, val) => typeof val === type);
+const isObject = typeIs('object');
 
 function _createReducer(fixedReducers, asyncReducers = {}) {
   return combineReducers(assign({}, fixedReducers, asyncReducers));
@@ -7,6 +12,12 @@ function _createReducer(fixedReducers, asyncReducers = {}) {
 
 export function addReducer(store) {
   return (name, reducer) => {
+    invariant(
+      isObject(store.fixedReducers),
+      'To use async reducers, the reducer parameter passed to createStoreWith must be an Object. Instead received %s.',
+      typeof store.fixedReducers
+    );
+
     store.asyncReducers[name] = reducer;
     store.replaceReducer(_createReducer(store.fixedReducers, store.asyncReducers));
   };
@@ -14,6 +25,12 @@ export function addReducer(store) {
 
 export function removeReducer(store) {
   return (name) => {
+    invariant(
+      isObject(store.fixedReducers),
+      'To use async reducers, the reducer parameter passed to createStoreWith must be an Object. Instead received %s.',
+      typeof store.fixedReducers
+    );
+
     delete store.asyncReducers[name];
     store.replaceReducer(_createReducer(store.fixedReducers, store.asyncReducers));
   };

--- a/test/utils/dynamicReducers.spec.js
+++ b/test/utils/dynamicReducers.spec.js
@@ -7,6 +7,7 @@ describe('Utils', () => {
 
       const fakeStore = {
           asyncReducers: {},
+          fixedReducers: {},
           replaceReducer: (newReducer) => {
             return newReducer;
           }
@@ -24,6 +25,7 @@ describe('Utils', () => {
 
       const fakeStore = {
           asyncReducers: { test: 'a test' },
+          fixedReducers: {},
           replaceReducer: (newReducer) => {
             return newReducer;
           }

--- a/test/utils/dynamicReducers.spec.js
+++ b/test/utils/dynamicReducers.spec.js
@@ -1,0 +1,42 @@
+import expect from 'expect';
+import { addReducer, removeReducer } from '../../src/utils/dynamicReducers';
+
+describe('Utils', () => {
+  describe('dynamicReducers', () => {
+    it('returns a function that adds a new async reducer', () => {
+
+      const fakeStore = {
+          asyncReducers: {},
+          replaceReducer: (newReducer) => {
+            return newReducer;
+          }
+      };
+
+      const result = addReducer(fakeStore);
+      expect(result).toBeA(Function);
+      expect(() => result('test', { actionHandler: () => { console.log('hi'); }})).toBeA(Function);
+      expect(Object.keys(fakeStore.asyncReducers).length).toEqual(0);
+      result('test', { actionHandler: () => { console.log('hi'); }});
+      expect(Object.keys(fakeStore.asyncReducers).length).toEqual(1);
+    });
+
+    it('returns a function that removes an existing async reducer', () => {
+
+      const fakeStore = {
+          asyncReducers: { test: 'a test' },
+          replaceReducer: (newReducer) => {
+            return newReducer;
+          }
+      };
+
+      const result = removeReducer(fakeStore);
+      expect(result).toBeA(Function);
+      expect(() => result('test')).toBeA(Function);
+      expect(Object.keys(fakeStore.asyncReducers).length).toEqual(1);
+      result('fail');
+      expect(Object.keys(fakeStore.asyncReducers).length).toEqual(1);
+      result('test');
+      expect(Object.keys(fakeStore.asyncReducers).length).toEqual(0);
+    });
+  });
+});


### PR DESCRIPTION
This is an attempt to solve the need to add or remove dinamically reducers to the store created with ng-redux.

The idea is very simple:
- at config time we create the store with some "fixed" reducers that our application will always use
- when the store is created, ng-redux adds to the store a new property called asyncReducers, which will store the reducers that we add or remove on execution time
- we also add two methods to the created store: addReducer and removeReducer which adds or removes a reducer from the asyncReducers property, and replaces the store reducer with the combination of the "fixed" and "async" reducers.
- addReducer gets two parameters: the name of the reducer to be appended and the reducer itself
- removeReducer gets only one parameter: the name of the reducer to be removed

There's a "small" problem. To get this solution to work, we need to pass and object to createStore (which will be stored also on the store object and combined with the async reducers) and not with a function, because we can't combine reducers from combined ones (at least with the standard redux combineReducers function), and we need to combineReducers each time we add or remove a new reducer.

This could be used to solve the issue #75 

Hope that this helps somebody, and you find it useful
