### PR TITLE
Type definition now includes a 4th parameter on createStoreWith

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,7 +28,7 @@ export interface INgRedux {
 }
 
 export interface INgReduxProvider {
-    createStoreWith(reducer: Reducer, middlewares?: Array<Middleware | string>, storeEnhancers?: Function[]): void;
+    createStoreWith(reducer: Reducer, middlewares?: Array<Middleware | string>, storeEnhancers?: Function[], initialState?: any): void;
 }
 
 export var ngRedux: string;


### PR DESCRIPTION
This makes the type definition consistent with the documentation.

This 4th parameter represents an optional initial state.