### PR TITLE
fix: Replace lodash assign with Object.assign for symbol copy

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   },
   "dependencies": {
     "invariant": "^2.1.0",
-    "lodash.assign": "^3.2.0",
     "lodash.curry": "^4.0.1",
     "lodash.isarray": "^3.0.4",
     "lodash.isfunction": "^3.0.6",

--- a/src/components/connector.js
+++ b/src/components/connector.js
@@ -5,8 +5,8 @@ import invariant from 'invariant';
 import isPlainObject from 'lodash.isplainobject';
 import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
-import assign from 'lodash.assign';
 
+const assign = Object.assign;
 const defaultMapStateToTarget = () => ({});
 const defaultMapDispatchToTarget = dispatch => ({dispatch});
 

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -3,7 +3,6 @@ import invariant from 'invariant';
 import {createStore, applyMiddleware, compose, combineReducers} from 'redux';
 import digestMiddleware from './digestMiddleware';
 
-import assign from 'lodash.assign';
 import curry from 'lodash.curry';
 import isArray from 'lodash.isarray';
 import isFunction from 'lodash.isfunction';
@@ -12,6 +11,7 @@ import map from 'lodash.map';
 const typeIs = curry((type, val) => typeof val === type);
 const isObject = typeIs('object');
 const isString = typeIs('string');
+const assign  = Object.assign;
 
 export default function ngReduxProvider() {
   let _reducer = undefined;

--- a/test/components/connector.spec.js
+++ b/test/components/connector.spec.js
@@ -3,7 +3,8 @@ let sinon = require('sinon');
 import { createStore } from 'redux';
 import Connector from '../../src/components/connector';
 import isFunction from 'lodash.isfunction';
-import assign from 'lodash.assign';
+
+const assign = Object.assign;
 
 describe('Connector', () => {
   let store;


### PR DESCRIPTION
Ref: #129 #141

Replacement for original #129 solution. I'm replacing lodash's assign with `Object.assign` which copies over not only object keys/values but also Symbols.