### PR TITLE
feat(scripts): Use NPM path resolution over custom paths to binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "./lib/index.js",
   "scripts": {
     "build": "npm run build:lib && npm run build:min && npm run build:max",
-    "build:lib": "rm -rf lib && `npm bin`/babel src --out-dir lib",
-    "build:min": "./node_modules/.bin/webpack --optimize-minimize lib/index.js dist/ng-redux.min.js",
-    "build:max": "./node_modules/.bin/webpack lib/index.js dist/ng-redux.js",
+    "build:lib": "rm -rf lib && babel src --out-dir lib",
+    "build:min": "webpack --optimize-minimize lib/index.js dist/ng-redux.min.js",
+    "build:max": "webpack lib/index.js dist/ng-redux.js",
     "test": "mocha --compilers js:babel-register --recursive"
   },
   "repository": {


### PR DESCRIPTION
The `./node_modules/.bin` works fine; however, it's preferred to use `npm bin`. Unfortunately `\`npm bin\`` doesn't work on Windows machines so I'm switching to just using the binaries directly. The upside of doing that is that NPM automatically prepends PATH with `./node_modules/.bin` contents so there is no reason to refer to them directly.