### PR TITLE
chore(build): set production environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:min && npm run build:max",
     "build:lib": "rm -rf lib && babel src --out-dir lib",
-    "build:min": "webpack --optimize-minimize lib/index.js dist/ng-redux.min.js",
+    "build:min": "webpack --optimize-minimize --define process.env.NODE_ENV=\"'production'\" lib/index.js dist/ng-redux.min.js",
     "build:max": "webpack lib/index.js dist/ng-redux.js",
     "test": "mocha --compilers js:babel-register --recursive"
   },


### PR DESCRIPTION
`build:min` is not setting production environment.

So this causes to log to the console even when building for production plus we are not getting webpack to optimize accordingly for prod.
>   You are currently using minified code outside of NODE_ENV === \'production\'.                                                                                           This means that you are running a slower development build of Redux.                                                                                      
You can use loose-envify (https://github.com/zertosh/loose-envify) for browserify or DefinePlugin for webpack (http://stackoverflow.com/questions/30030031) to ensure you have the correct code for your production build.' 

@AntJanus 

We probably want to upgrade to a newer version of webpack too.

Should close https://github.com/angular-redux/ng-redux/pull/126