### PR TITLE
fix(assign): Now using ponyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "lodash.isobject": "^3.0.2",
     "lodash.isplainobject": "^4.0.6",
     "lodash.map": "^4.6.0",
+    "object-assign": "^4.1.1",
     "redux": "^3.7.2"
   },
   "czConfig": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -19,6 +19,7 @@ if (env === 'es' || env === 'cjs') {
     'lodash.isobject',
     'lodash.isplainobject',
     'lodash.map',
+    'object-assign',
     'redux',
   ];
   config.plugins.push(

--- a/src/components/connector.js
+++ b/src/components/connector.js
@@ -2,11 +2,11 @@ import shallowEqual from '../utils/shallowEqual';
 import wrapActionCreators from '../utils/wrapActionCreators';
 import invariant from 'invariant';
 
+import assign from 'object-assign';
 import isPlainObject from 'lodash.isplainobject';
 import isFunction from 'lodash.isfunction';
 import isObject from 'lodash.isobject';
 
-const assign = Object.assign;
 const defaultMapStateToTarget = () => ({});
 const defaultMapDispatchToTarget = dispatch => ({dispatch});
 

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -3,6 +3,7 @@ import invariant from 'invariant';
 import {createStore, applyMiddleware, compose, combineReducers} from 'redux';
 import digestMiddleware from './digestMiddleware';
 
+import assign from 'object-assign';
 import curry from 'lodash.curry';
 import isFunction from 'lodash.isfunction';
 import map from 'lodash.map';
@@ -12,7 +13,6 @@ const isArray = Array.isArray;
 const typeIs = curry((type, val) => typeof val === type);
 const isObject = typeIs('object');
 const isString = typeIs('string');
-const assign  = Object.assign;
 
 export default function ngReduxProvider() {
   let _reducer = undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1799,7 +1799,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 


### PR DESCRIPTION
Now using ponyfill for Object.assign that will try to use browser's
native and fallback to its implementation.

Closes: https://github.com/angular-redux/ng-redux/issues/152