### PR TITLE
fix(build): Removed browser entry from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "ng-redux",
   "version": "3.5.0",
   "description": "Redux bindings for Angular.js",
-  "browser": "dist/ng-redux.js",
   "main": "lib/ng-redux.js",
   "module": "es/ng-redux.js",
   "typings": "./index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,15 +30,15 @@ if (env === 'development' || env === 'production') {
   config.format = 'umd';
   config.moduleName = 'NgRedux';
   config.plugins.push(
+    replace({
+      'process.env.NODE_ENV': JSON.stringify(env)
+    }),
     nodeResolve({
       jsnext: true,
     }),
     commonjs(),
     babel({
       exclude: 'node_modules/**'
-    }),
-    replace({
-      'process.env.NODE_ENV': JSON.stringify(env)
     })
   )
 }


### PR DESCRIPTION
Fix for https://github.com/angular-redux/ng-redux/issues/156:

So there were 2 issues, first the `replace` plugin has to go before other plugins such as `commonjs`.

Also we had `browser` in package.json which Webpack will default to when resolving modules, so instead of resolving to `lib/ng-redux.js` (main) or `es/ng-redux.js` (module) it was resolving to `dist/ng-redux.js` which we build with env set to `development` https://github.com/angular-redux/ng-redux/blob/e1973f7d95059ec6f36259d972c9e69170f248ec/package.json#L20

FYI @maxlapides