### PR TITLE
Adjust store creation to resolve issue with redux-first-router

### DIFF
--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -36,9 +36,9 @@ export default function ngReduxProvider() {
 
     _reducer = reducer;
     _reducerIsObject = isObject(reducer);
-    _storeEnhancers = storeEnhancers
+    _storeEnhancers = storeEnhancers || [];
     _middlewares = middlewares || [];
-    _initialState = initialState;
+    _initialState = initialState || {};
   };
 
   this.$get = ($injector) => {
@@ -54,7 +54,7 @@ export default function ngReduxProvider() {
 
     const resolvedStoreEnhancer = map(_storeEnhancers, resolveStoreEnhancer);
 
-    if(_reducerIsObject) {
+    if (_reducerIsObject) {
       const getReducerKey = key => isString(_reducer[key])
         ? $injector.get(_reducer[key])
         : _reducer[key];
@@ -70,14 +70,14 @@ export default function ngReduxProvider() {
       _reducer = combineReducers(reducersObj);
     }
 
-    const finalCreateStore = resolvedStoreEnhancer ? compose(...resolvedStoreEnhancer)(createStore) : createStore;
-
-    //digestMiddleware needs to be the last one.
+    // digestMiddleware needs to be the last one.
     resolvedMiddleware.push(digestMiddleware($injector.get('$rootScope')));
 
-    const store = _initialState
-      ? applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer, _initialState)
-      : applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer);
+    // combine middleware into a store enhancer.
+    const middlewares = applyMiddleware(...resolvedMiddleware);
+
+    // compose enhancers with middleware and create store.
+    const store = createStore(_reducer, _initialState, compose(...resolvedStoreEnhancer, middlewares));
 
     return assign({}, store, { connect: Connector(store) });
   };


### PR DESCRIPTION
There is an existing issue when using ng-redux with [redux-first-router (RFR)](https://github.com/faceyspacey/redux-first-router).

When first loading the page RFR dispatches an action for the matched route. Due to how ng-redux creates the store this action is not passed to the registered middleware. I tested creating the store separately and passing this into ng-redux using the method outlined at the end of #19 but this then caused the digest loop to not be updated with the new state (due to the digestMiddleware not being added to the same middleware chain).

These changes to store creation mean the store is created as per the redux documentation and the middleware is initialised at the same time as the other store enhancers, thus preventing the action being swallowed.

This is very much an edge case and this was a quick fix for us so it may not meet your guidelines for PRs.