### PR TITLE
Changing subscribe's return type in Reducer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import { Unsubscribe } from 'redux';
+
 declare namespace ngRedux {
   export interface Reducer extends Function {
       (state: any, action: any): any;
@@ -21,7 +23,7 @@ declare namespace ngRedux {
       replaceReducer(nextReducer: Reducer): void;
       dispatch(action: any): any;
       getState(): any;
-      subscribe(listener: Function): Function;
+      subscribe(listener: Function): Unsubscribe;
       connect(
           mapStateToTarget: (state: any) => Object,
           mapDispatchToTarget?: Object | ((dispatch: Function) => Object)


### PR DESCRIPTION
Changed the return type of subscribe(listener: Function) since redux
defines it as "Unsubscribe". Although using Function works, it may result
in TypeScript errors in certain use cases.

http://redux.js.org/docs/api/Store.html#subscribe