### PR TITLE
Debounce of the digests triggered by store modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ es
 coverage
 *.tgz
 examples/**/dist
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ angular.module('ngapplication').config(($ngReduxProvider) => {
   // eslint-disable-next-line
   $ngReduxProvider.config.debounce = {
     wait: 100,
-    mawWait: 500,
+    maxWait: 500,
   };
 });
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For Angular 2 see [ng2-redux](https://github.com/wbuchwalter/ng2-redux).
 - [API](#api)
 - [Dependency Injectable Middleware](#dependency-injectable-middleware)
 - [Routers](#routers)
-- [Debouncing the digest](#debouncing-the-digest)
+- [Config](#config)
 - [Using DevTools](#using-devtools)
 - [Additional Resources](#additional-resources)
 
@@ -189,7 +189,9 @@ $ngReduxProvider.createStoreWith(reducers, [thunk, 'myInjectableMiddleware']);
 
 Middlewares passed as **string** will then be resolved throught angular's injector.
 
-## Debouncing the digest
+## Config
+
+### Debouncing the digest
 You can debounce the digest triggered by store modification (usefull in huge apps with a  lot of store modification) by passing a config parameter to the `ngReduxProvider`.
 
 ```javascript
@@ -201,11 +203,14 @@ angular.module('ngapplication').config(($ngReduxProvider) => {
   // eslint-disable-next-line
   $ngReduxProvider.config.debounce = {
     wait: 100,
+    mawWait: 500,
   };
 });
 ```
 
-This will debounce the digest 100ms. Every store modification within this time will be handled by this digest.
+This will debounce the digest for 100ms with a maximum defaly time of 500ms. Every store modification within this time will be handled by this digest.
+
+[lodash.debounce](https://lodash.com/docs/4.17.4#debounce) is used for the debouncing.
 
 ## Routers
 See [redux-ui-router](https://github.com/neilff/redux-ui-router) to make ng-redux and UI-Router work together. <br>

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ angular.module('ngapplication').config(($ngReduxProvider) => {
 });
 ```
 
-This will debounce the digest for 100ms with a maximum defaly time of 500ms. Every store modification within this time will be handled by this digest.
+This will debounce the digest for 100ms with a maximum delay time of 500ms. Every store modification within this time will be handled by this delayed digest.
 
 [lodash.debounce](https://lodash.com/docs/4.17.4#debounce) is used for the debouncing.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ For Angular 2 see [ng2-redux](https://github.com/wbuchwalter/ng2-redux).
 - [API](#api)
 - [Dependency Injectable Middleware](#dependency-injectable-middleware)
 - [Routers](#routers)
+- [Debouncing the digest](#debouncing-the-digest)
 - [Using DevTools](#using-devtools)
 - [Additional Resources](#additional-resources)
 
@@ -187,6 +188,24 @@ $ngReduxProvider.createStoreWith(reducers, [thunk, 'myInjectableMiddleware']);
 ```
 
 Middlewares passed as **string** will then be resolved throught angular's injector.
+
+## Debouncing the digest
+You can debounce the digest triggered by store modification (usefull in huge apps with a  lot of store modification) by passing a config parameter to the `ngReduxProvider`.
+
+```javascript
+import angular from 'angular';
+
+angular.module('ngapplication').config(($ngReduxProvider) => {
+  'ngInject';
+
+  // eslint-disable-next-line
+  $ngReduxProvider.config.debounce = {
+    wait: 100,
+  };
+});
+```
+
+This will debounce the digest 100ms. Every store modification within this time will be handled by this digest.
 
 ## Routers
 See [redux-ui-router](https://github.com/neilff/redux-ui-router) to make ng-redux and UI-Router work together. <br>

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Middlewares passed as **string** will then be resolved throught angular's inject
 ## Config
 
 ### Debouncing the digest
-You can debounce the digest triggered by store modification (usefull in huge apps with a  lot of store modification) by passing a config parameter to the `ngReduxProvider`.
+You can debounce the digest triggered by store modification (usefull in huge apps with a  lot of store modifications) by passing a config parameter to the `ngReduxProvider`.
 
 ```javascript
 import angular from 'angular';

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "babel-runtime": "^6.26.0",
     "invariant": "^2.2.2",
     "lodash.curry": "^4.1.1",
+    "lodash.debounce": "^4.0.8",
     "lodash.isfunction": "^3.0.8",
     "lodash.isobject": "^3.0.2",
     "lodash.isplainobject": "^4.0.6",

--- a/src/components/digestMiddleware.js
+++ b/src/components/digestMiddleware.js
@@ -1,7 +1,17 @@
-export default function digestMiddleware($rootScope) {
+let toRun;
+
+export default function digestMiddleware($rootScope, debounceConfig) {
   return store => next => action => {
-      const res = next(action);
-      $rootScope.$evalAsync(res);
-      return res;
+    const res = next(action);
+    if(debounceConfig && debounceConfig.wait && debounceConfig.wait > 0) {
+      toRun = res;
+      window.setTimeout(() => {
+        $rootScope.$evalAsync(toRun);
+        toRun = undefined;
+      }, debounceConfig.wait);
+    } else {
+      $rootScope.$evalAsync(toRun);
+    }
+    return res;
   };
 }

--- a/src/components/digestMiddleware.js
+++ b/src/components/digestMiddleware.js
@@ -1,9 +1,11 @@
 import debounce from 'lodash.debounce';
 
 export default function digestMiddleware($rootScope, debounceConfig) {
-  let debouncedFunction = $rootScope.$evalAsync;
+  let debouncedFunction = (expr) => {
+    $rootScope.$evalAsync(expr);
+  };
   if(debounceConfig && debounceConfig.wait && debounceConfig.wait > 0) {
-    debouncedFunction = debounce($rootScope.$evalAsync, debounceConfig.wait, { maxWait: debounceConfig.maxWait });
+    debouncedFunction = debounce(debouncedFunction, debounceConfig.wait, { maxWait: debounceConfig.maxWait });
   }
   return store => next => action => {
     const res = next(action);

--- a/src/components/digestMiddleware.js
+++ b/src/components/digestMiddleware.js
@@ -1,17 +1,13 @@
-let toRun;
+import debounce from 'lodash.debounce';
 
 export default function digestMiddleware($rootScope, debounceConfig) {
+  let debouncedFunction = $rootScope.$evalAsync;
+  if(debounceConfig && debounceConfig.wait && debounceConfig.wait > 0) {
+    debouncedFunction = debounce($rootScope.$evalAsync, debounceConfig.wait, { maxWait: debounceConfig.maxWait });
+  }
   return store => next => action => {
     const res = next(action);
-    if(debounceConfig && debounceConfig.wait && debounceConfig.wait > 0) {
-      toRun = res;
-      window.setTimeout(() => {
-        $rootScope.$evalAsync(toRun);
-        toRun = undefined;
-      }, debounceConfig.wait);
-    } else {
-      $rootScope.$evalAsync(toRun);
-    }
+    debouncedFunction(res);
     return res;
   };
 }

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -44,6 +44,7 @@ export default function ngReduxProvider() {
   this.config = {
     debounce: {
       wait: undefined,
+      maxWait: undefined,
     },
   };
 
@@ -83,7 +84,7 @@ export default function ngReduxProvider() {
     const middlewares = applyMiddleware(...resolvedMiddleware);
 
     // compose enhancers with middleware and create store.
-    const store = createStore(_reducer, _initialState, compose(...resolvedStoreEnhancer, middlewares));
+    const store = createStore(_reducer, _initialState, compose(middlewares, ...resolvedStoreEnhancer));
 
     return assign({}, store, { connect: Connector(store) });
   };

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -41,6 +41,12 @@ export default function ngReduxProvider() {
     _initialState = initialState || {};
   };
 
+  this.config = {
+    debounce: {
+      wait: undefined,
+    },
+  };
+
   this.$get = ($injector) => {
     const resolveMiddleware = middleware => isString(middleware)
       ? $injector.get(middleware)
@@ -71,7 +77,7 @@ export default function ngReduxProvider() {
     }
 
     // digestMiddleware needs to be the last one.
-    resolvedMiddleware.push(digestMiddleware($injector.get('$rootScope')));
+    resolvedMiddleware.push(digestMiddleware($injector.get('$rootScope'), this.config.debounce));
 
     // combine middleware into a store enhancer.
     const middlewares = applyMiddleware(...resolvedMiddleware);

--- a/test/components/digestMiddleware.spec.js
+++ b/test/components/digestMiddleware.spec.js
@@ -1,0 +1,64 @@
+import expect from 'expect';
+import sinon from 'sinon';
+import digestMiddleware from '../../src/components/digestMiddleware';
+
+
+describe('digestMiddleware', () => {
+
+  it('Should debounce the $evalAsync function if debounce is enabled', (done) => {
+    const $evalAsync = sinon.spy();
+    const $rootScope = {
+      $evalAsync,
+    };
+    const firstAction = 1;
+    const secondAction = 2;
+    const debounceConfig = {
+      wait: 10,
+    };
+    const next = sinon.spy((action) => (action));
+    const middleware = digestMiddleware($rootScope, debounceConfig);
+    middleware()(next)(firstAction);
+    setTimeout(() => {
+      middleware()(next)(secondAction);
+    }, 1);
+    setTimeout(() => {
+      expect($evalAsync.calledOnce).toBe(true);
+      expect(next.calledTwice).toBe(true);
+      expect(next.firstCall.calledWithExactly(firstAction)).toBe(true);
+      expect(next.secondCall.calledWithExactly(secondAction)).toBe(true);
+      expect($evalAsync.firstCall.calledWithExactly(secondAction)).toBe(true);
+      done();
+    }, debounceConfig.wait + 10);
+
+  });
+
+  it('Should not debounce the $evalAsync function if debounce is disabled', () => {
+    const disabledDebounceConfigs = [
+      null,
+      undefined,
+      {},
+      { wait: 0 },
+    ];
+    disabledDebounceConfigs.forEach(() => {
+      const $evalAsync = sinon.spy();
+      const $rootScope = {
+        $evalAsync,
+      };
+      const firstAction = 1;
+      const secondAction = 2;
+      const debounceConfig = {};
+
+      const next = sinon.spy((action) => (action));
+      const middleware = digestMiddleware($rootScope, debounceConfig);
+      middleware()(next)(firstAction);
+      middleware()(next)(secondAction);
+      expect($evalAsync.calledTwice).toBe(true);
+      expect(next.calledTwice).toBe(true);
+      expect(next.firstCall.calledWithExactly(firstAction)).toBe(true);
+      expect(next.secondCall.calledWithExactly(secondAction)).toBe(true);
+      expect($evalAsync.firstCall.calledWithExactly(firstAction)).toBe(true);
+      expect($evalAsync.secondCall.calledWithExactly(secondAction)).toBe(true);
+    });
+  });
+
+});


### PR DESCRIPTION
# capability for ngRedux to debounce the digests

## The problem
In my huge app, I have a lot of stimulations that modify the store and each one lead to a digest (via $rootScope.$evalAsync). The accumulation of digests considerably affect the performance of the application. 

## Solution

We added a use of lodash.debounce in the digest middleware to avoid digesting too much.

## Content of the PR 

- add lodash.debounce to the dependencies
- Use of lodash.debounce in the digest middleware
- Creation of a config for ngRedux
- Documentation of the config
- unit test for the debounce
- Correction of a problem with redux-thunk in ngRedux.js

## Use of the fonctionnality in my app 

```javascript
import angular from 'angular';

angular.module('ngapplication').config(($ngReduxProvider) => {
  'ngInject';

  // eslint-disable-next-line
  $ngReduxProvider.config.debounce = {
    wait: 250,
    maxWait: 500,
  };
});
```

## last but not least

Thx for your usefull lib ;-)