### PR TITLE
feat(lib): provide store functionality

### DIFF
--- a/src/components/storeWrapper.js
+++ b/src/components/storeWrapper.js
@@ -1,0 +1,16 @@
+export default function wrapStore(providedStore, ngReduxStore) {
+  const unsubscribe = providedStore
+    .subscribe(() => {
+      let newState = providedStore.getState();
+
+      ngReduxStore.dispatch(newState);
+    })
+  ;
+
+  return Object.assign({},
+    providedStore,
+    {
+      subscribe: ngReduxStore.subscribe
+    })
+  ;
+}


### PR DESCRIPTION
Ref: https://github.com/angular-redux/ng-redux/issues/19

@deini would love some input on this. Here's the idea:

1. when you dispatch, dispatch goes through the provided store. The provided store does its magic and triggers all of its subscribers (Angular and non-Angular)
2. ng-redux creates an "empty" store which has a pass-through reducer (state => state)
3. ng-redux subscribes to the provided store and on state update, dispatches the entire state to the "empty" store
4. ng-redux users subscribe to the "empty" store and get notified as usual of any and all changes.

I haven't tested this out yet.
  