### PR TITLE
feat(lib): provide store functionality (resubmitted)

### DIFF
--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -84,7 +84,10 @@ export default function ngReduxProvider() {
     //digestMiddleware needs to be the last one.
     resolvedMiddleware.push(digestMiddleware($injector.get('$rootScope')));
 
-    const store = applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer, _initialState || undefined)
+    const store = _initialState
+      ? applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer, _initialState)
+      : applyMiddleware(...resolvedMiddleware)(finalCreateStore)(_reducer);
+
     const mergedStore = assign({}, store, { connect: Connector(store) });
     
     if (_providedStore) wrapStore(_providedStore, mergedStore)

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -24,10 +24,11 @@ export default function ngReduxProvider() {
   let _reducerIsObject = undefined;
   let _providedStore = undefined;
 
-  this.provideStore = (store) => {
+  this.provideStore = (store, middlewares = [], storeEnhancers) => {
     _providedStore = store;
     _reducer = (state, action) => action.payload;
-    _middlewares = [providedStoreMiddleware(_providedStore)];
+    _storeEnhancers = storeEnhancers;
+    _middlewares = [...middlewares, providedStoreMiddleware(store)];
   }
 
   this.createStoreWith = (reducer, middlewares, storeEnhancers, initialState) => {
@@ -45,7 +46,7 @@ export default function ngReduxProvider() {
 
     _reducer = reducer;
     _reducerIsObject = isObject(reducer);
-    _storeEnhancers = storeEnhancers
+    _storeEnhancers = storeEnhancers;
     _middlewares = middlewares || [];
     _initialState = initialState;
   };
@@ -90,7 +91,7 @@ export default function ngReduxProvider() {
 
     const mergedStore = assign({}, store, { connect: Connector(store) });
     
-    if (_providedStore) wrapStore(_providedStore, mergedStore)
+    if (_providedStore) wrapStore(_providedStore, mergedStore);
 
     return mergedStore;
   };

--- a/src/components/providedStoreMiddleware.js
+++ b/src/components/providedStoreMiddleware.js
@@ -1,0 +1,11 @@
+/**
+ * middleware for the empty store that ng-redux uses when a external store is provided
+ * Provides two cases:
+ * 1. NGREDUX_PASSTHROUGH, where data is coming IN to the "fake" store
+ * 2. all other, where actions are dispatched out, and proxied to the true store
+ */
+export default _providedStore => store => next => action => {
+  return action.type === '@@NGREDUX_PASSTHROUGH'
+    ? next(action)
+    : _providedStore.dispatch(action)
+}

--- a/src/components/storeWrapper.js
+++ b/src/components/storeWrapper.js
@@ -2,15 +2,10 @@ export default function wrapStore(providedStore, ngReduxStore) {
   const unsubscribe = providedStore
     .subscribe(() => {
       let newState = providedStore.getState();
-
-      ngReduxStore.dispatch(newState);
-    })
-  ;
-
-  return Object.assign({},
-    providedStore,
-    {
-      subscribe: ngReduxStore.subscribe
+      ngReduxStore.dispatch({
+        type: '@@NGREDUX_PASSTHROUGH',
+        payload: newState
+      });
     })
   ;
 }

--- a/src/components/storeWrapper.js
+++ b/src/components/storeWrapper.js
@@ -1,11 +1,10 @@
 export default function wrapStore(providedStore, ngReduxStore) {
-  const unsubscribe = providedStore
-    .subscribe(() => {
-      let newState = providedStore.getState();
-      ngReduxStore.dispatch({
-        type: '@@NGREDUX_PASSTHROUGH',
-        payload: newState
-      });
-    })
-  ;
+  providedStore.subscribe(() => {
+    let newState = providedStore.getState();
+    ngReduxStore.dispatch({
+      type: '@@NGREDUX_PASSTHROUGH',
+      payload: newState
+    });
+  });
+  providedStore.dispatch({ type: '@@NGREDUX_PASSTHROUGH_INIT' })
 }

--- a/src/components/storeWrapper.js
+++ b/src/components/storeWrapper.js
@@ -1,0 +1,16 @@
+export default function wrapStore(providedStore, ngReduxStore) {
+  const unsubscribe = providedStore
+    .subscribe(() => {
+      let newState = providedStore.getState();
+
+      ngReduxStore.dispatch(newState);
+    })
+  ;
+
+  return Object.assign({},
+    providedStore,
+    {
+      subscribe: ngReduxStore.subscribe
+    })
+  ;
+}


### PR DESCRIPTION
For #19 

_This started as a fork of #185._

## What this does
- adds ability to provide an existing redux store instead of always creating a new one.
- when a store is provided, a local copy is made within ng-redux which is always updated with the full state of the primary store.
- dispatches _to_ the ng-redux copy are proxied back to the primary store via middleware.

## Notes
Credit to @AntJanus for getting the ball rolling on this. I couldn't think of a better solution to the problem, but open to suggestions.

@AntJanus, unlike your implementation, i stuck to always returning the ng-redux store and just proxying dispatches back up instead of returning the merge of the provided store with the patched in subscribe method from the ng-redux store. If this isn't optimal, let me know.

@deini, you were mentioned in the original PR for feedback, so mentioning you here again.