### PR TITLE
Resolution of problem with some versions of npm/node

### DIFF
--- a/examples/counter/webpack.config.js
+++ b/examples/counter/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
   ],
   output: {
     path: path.join(__dirname, 'dist'),
-    filename: 'bundle.js'
+    filename: 'bundle.js',
+    publicPath:''
   },
   plugins: [
     new HtmlWebpackPlugin({


### PR DESCRIPTION
I've experienced problems when trying to launch the example project using Node@8.9.4/npm@5.6.0.
The solution was found here : https://github.com/webpack/webpack/issues/3242