### PR TITLE
chore(lib): update lodash and redux dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-redux",
-  "version": "4.0.3",
+  "version": "4.1.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -362,7 +362,7 @@
         "convert-source-map": "1.5.0",
         "debug": "2.6.8",
         "json5": "0.5.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.7",
@@ -381,7 +381,7 @@
         "babel-types": "6.25.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "source-map": "0.5.6",
         "trim-right": "1.0.1"
       }
@@ -418,7 +418,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-explode-assignable-expression": {
@@ -483,7 +483,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "babel-helper-remap-async-to-generator": {
@@ -598,7 +598,7 @@
         "babel-template": "6.25.0",
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
-        "lodash": "4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -916,7 +916,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.4.1",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.15"
       }
@@ -940,7 +940,7 @@
         "babel-traverse": "6.25.0",
         "babel-types": "6.25.0",
         "babylon": "6.17.4",
-        "lodash": "4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "babel-traverse": {
@@ -957,7 +957,7 @@
         "debug": "2.6.8",
         "globals": "9.18.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4"
+        "lodash": "4.17.11"
       }
     },
     "babel-types": {
@@ -968,7 +968,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -1204,7 +1204,7 @@
         "git-raw-commits": "1.3.0",
         "git-remote-origin-url": "2.0.0",
         "git-semver-tags": "1.3.0",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "normalize-package-data": "2.4.0",
         "q": "1.5.1",
         "read-pkg": "1.1.0",
@@ -1292,7 +1292,7 @@
         "dateformat": "1.0.12",
         "handlebars": "4.0.11",
         "json-stringify-safe": "5.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "meow": "3.7.0",
         "semver": "5.4.1",
         "split": "1.0.1",
@@ -1328,7 +1328,7 @@
       "requires": {
         "JSONStream": "1.3.2",
         "is-text-path": "1.0.1",
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "meow": "3.7.0",
         "split2": "2.2.0",
         "through2": "2.0.3",
@@ -2365,10 +2365,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.4",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-      "dev": true
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "lodash-es": {
       "version": "4.17.4",
@@ -2433,31 +2432,11 @@
         "lodash._isiterateecall": "3.0.9"
       }
     },
-    "lodash.curry": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.curry/-/lodash.curry-4.1.1.tgz",
-      "integrity": "sha1-JI42By7ekGUB11lmIAqG2riyMXA="
-    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
       "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
       "dev": true
-    },
-    "lodash.isfunction": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.8.tgz",
-      "integrity": "sha1-TbcJ/IG8So/XEnpFilNGxc3OLGs="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
-    },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.kebabcase": {
       "version": "4.1.1",
@@ -2483,11 +2462,6 @@
           "dev": true
         }
       }
-    },
-    "lodash.map": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.merge": {
       "version": "4.6.0",
@@ -3181,7 +3155,7 @@
       "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
       "dev": true,
       "requires": {
-        "lodash": "4.17.4",
+        "lodash": "4.17.11",
         "lodash-es": "4.17.4",
         "loose-envify": "1.3.1",
         "symbol-observable": "1.0.4"

--- a/package.json
+++ b/package.json
@@ -58,14 +58,9 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "invariant": "^2.2.2",
-    "lodash.curry": "^4.1.1",
-    "lodash.debounce": "^4.0.8",
-    "lodash.isfunction": "^3.0.8",
-    "lodash.isobject": "^3.0.2",
-    "lodash.isplainobject": "^4.0.6",
-    "lodash.map": "^4.6.0"
+    "lodash": "4.17.11"
   },
   "peerDependencies": {
-    "redux": "^3.0.0"
+    "redux": ">3.0.0"
   }
 }

--- a/src/components/connector.js
+++ b/src/components/connector.js
@@ -2,9 +2,9 @@ import shallowEqual from '../utils/shallowEqual';
 import wrapActionCreators from '../utils/wrapActionCreators';
 import invariant from 'invariant';
 
-import isPlainObject from 'lodash.isplainobject';
-import isFunction from 'lodash.isfunction';
-import isObject from 'lodash.isobject';
+import isPlainObject from 'lodash/isPlainObject';
+import isFunction from 'lodash/isFunction';
+import isObject from 'lodash/isObject';
 
 const assign = Object.assign;
 const defaultMapStateToTarget = () => ({});

--- a/src/components/digestMiddleware.js
+++ b/src/components/digestMiddleware.js
@@ -1,4 +1,4 @@
-import debounce from 'lodash.debounce';
+import debounce from 'lodash/debounce';
 
 export default function digestMiddleware($rootScope, debounceConfig) {
   let debouncedFunction = (expr) => {

--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -5,9 +5,9 @@ import digestMiddleware from './digestMiddleware';
 import providedStoreMiddleware from './providedStoreMiddleware';
 import wrapStore from './storeWrapper';
 
-import curry from 'lodash.curry';
-import isFunction from 'lodash.isfunction';
-import map from 'lodash.map';
+import curry from 'lodash/curry';
+import isFunction from 'lodash/isFunction';
+import map from 'lodash/map';
 
 const isArray = Array.isArray;
 
@@ -97,7 +97,7 @@ export default function ngReduxProvider() {
     const store = createStore(_reducer, _initialState, compose(middlewares, ...resolvedStoreEnhancer));
 
     const mergedStore = assign({}, store, { connect: Connector(store) });
-    
+
     if (_providedStore) wrapStore(_providedStore, mergedStore);
 
     return mergedStore;

--- a/test/components/connector.spec.js
+++ b/test/components/connector.spec.js
@@ -2,7 +2,7 @@ import expect from 'expect';
 let sinon = require('sinon');
 import { createStore } from 'redux';
 import Connector from '../../src/components/connector';
-import isFunction from 'lodash.isfunction';
+import isFunction from 'lodash/isFunction';
 
 const assign = Object.assign;
 


### PR DESCRIPTION
Closes #203 

passes tests.

This PR does a couple of things:

1. allows Redux 4 to be a peer dependency
2. updated lodash to newest version to bypass a security warning
3. unified lodash loading functions to use the all-encompassing `lodash` package; however, it only pulls in and compiles with the functions ng-redux uses
