### PR TITLE
Allow mapDispatchToTarget to be an ES6 module

### DIFF
--- a/src/components/connector.js
+++ b/src/components/connector.js
@@ -15,7 +15,7 @@ export default function Connector(store) {
 
     let finalMapStateToTarget = mapStateToTarget || defaultMapStateToTarget;
 
-    const finalMapDispatchToTarget = isPlainObject(mapDispatchToTarget) ?
+    const finalMapDispatchToTarget = isObject(mapDispatchToTarget) && !isFunction(mapDispatchToTarget) ?
       wrapActionCreators(mapDispatchToTarget) :
       mapDispatchToTarget || defaultMapDispatchToTarget;
 
@@ -25,7 +25,7 @@ export default function Connector(store) {
       );
 
     invariant(
-      isPlainObject(finalMapDispatchToTarget) || isFunction(finalMapDispatchToTarget),
+      isObject(finalMapDispatchToTarget) || isFunction(finalMapDispatchToTarget),
       'mapDispatchToTarget must be a plain Object or a Function. Instead received %s.', finalMapDispatchToTarget
       );
 

--- a/test/components/connector.spec.js
+++ b/test/components/connector.spec.js
@@ -114,6 +114,16 @@ describe('Connector', () => {
     expect(receivedDispatch).toBe(store.dispatch);
   });
 
+  it('Should allow ES6 modules', () => {
+    // The tests are run in Node, so we are unable to use actual ES6 modules. We get quite
+    // close by emulating it
+    class FakeModule {
+      prop() {}
+    };
+    const fakeModule = new FakeModule();
+    expect(() => connect(() => ({}), fakeModule)(targetObj)).toNotThrow();
+  });
+
   it('Should provide state slice, bound actions and previous state slice to target (function)', () => {
     const targetFunc = sinon.spy();
 


### PR DESCRIPTION
Allow connect to consume an ES6 module as the second parameter.

Motivation:
ES6 modules are more and more common in web development, and, from what I know, there are no reasons to not allow using them here. This patch is required for one of our internal projects to enable us to use the newest Webpack, so I hope that it will be found useful.

Questions:
Is the test enough to emulate the behaviour of an ES6 module in the NodeJS environment?

