### PR TITLE
chore: remove precise locking of lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,6 +260,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2626,7 +2627,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.3.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "invariant": "^2.2.2",
-    "lodash": "4.17.13"
+    "lodash": "^4.17.13"
   },
   "peerDependencies": {
     "redux": ">3.0.0"


### PR DESCRIPTION
Use the caret (^) operator to allow any version of lodash with a version over the specified
version (4.17.13).  This means that when this package is installed alongside other packages
depending on a higher version of lodash, the shared lodash dependencies can be deduped properly
across all dependents.

The caret also ensures that this package will not automatically upgrade to 5.x versions of
lodash (the next major version).

If it's preferred, I can also use the tilde (~) - this will lock the version to the current minor version.  I figured the caret would be okay, given that the other dependencies were locked with the caret.

**Motivation**: One of our applications is currently depending on multiple versions of lodash, even after using `npm dedupe`.  It's not terrible - this project does a good job of only using the necessary functions - but it would be nicer if we could dedupe them all.  If this library were to accept other versions of lodash (which would, at least assuming semver, be backwards compatible), then this would be resolved.

I hope this is okay, and useful!