### PR TITLE
chore(dependencies): updating lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2458,9 +2458,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash-es": {
       "version": "4.17.4",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "babel-runtime": "^6.26.0",
     "invariant": "^2.2.2",
-    "lodash": "^4.17.13"
+    "lodash": "^4.17.20"
   },
   "peerDependencies": {
     "redux": ">3.0.0"


### PR DESCRIPTION
Updating lodash to fix vulnerability affecting lodash versions < 4.17.17 

See https://snyk.io/vuln/SNYK-JS-LODASH-608086