### PR TITLE
unsubscribe from provided store when AngularJS app is destroyed

### DIFF
--- a/src/components/ngRedux.js
+++ b/src/components/ngRedux.js
@@ -107,7 +107,7 @@ export default function ngReduxProvider() {
 
     const mergedStore = assign({}, store, { connect: Connector(store) });
 
-    if (_providedStore) wrapStore(_providedStore, mergedStore);
+    if (_providedStore) wrapStore(_providedStore, mergedStore, injector.get('$rootScope'));
 
     return mergedStore;
   };

--- a/src/components/storeWrapper.js
+++ b/src/components/storeWrapper.js
@@ -1,5 +1,5 @@
-export default function wrapStore(providedStore, ngReduxStore) {
-  providedStore.subscribe(() => {
+export default function wrapStore(providedStore, ngReduxStore, $rootScope) {
+  const unsubscribe = providedStore.subscribe(() => {
     let newState = providedStore.getState();
     ngReduxStore.dispatch({
       type: '@@NGREDUX_PASSTHROUGH',
@@ -7,4 +7,5 @@ export default function wrapStore(providedStore, ngReduxStore) {
     });
   });
   providedStore.dispatch({ type: '@@NGREDUX_PASSTHROUGH_INIT' })
+  $rootScope.$on('$destroy', unsubscribe)
 }


### PR DESCRIPTION
This PR registers an unsubscribe callback with `$rootScope.$on('$destroy', ...)` in order to prevent the memory leak identified in https://github.com/angular-redux/ng-redux/issues/247.